### PR TITLE
Fix npm install and remove web3

### DIFF
--- a/scripts/FillDepositSubtree.js
+++ b/scripts/FillDepositSubtree.js
@@ -7,6 +7,7 @@ const TokenRegistry = artifacts.require("TokenRegistry");
 const TestToken = artifacts.require("TestToken");
 const DepositManager = artifacts.require("DepositManager");
 const RollupCore = artifacts.require("Rollup");
+const { ethers } = require("ethers");
 
 async function stake() {
   // get deployed name registry instance
@@ -38,7 +39,7 @@ async function stake() {
 
   await testToken.approve(
     depositManagerInstance.address,
-    web3.utils.toWei("1"),
+    ethers.utils.parseEther("1"),
     {
       from: wallets[0].getAddressString(),
     }

--- a/test/Deposit.spec.ts
+++ b/test/Deposit.spec.ts
@@ -48,7 +48,7 @@ contract("DepositManager", async function(accounts) {
     let depositManagerInstance = await DepositManager.deployed();
     let approveToken = await testToken.approve(
       depositManagerInstance.address,
-      web3.utils.toWei("1"),
+      ethers.utils.parseEther("1"),
       {
         from: wallets[0].getAddressString()
       }

--- a/test/Rollup.spec.ts
+++ b/test/Rollup.spec.ts
@@ -34,7 +34,7 @@ contract("Rollup", async function (accounts) {
     });
     await testToken.approve(
       depositManagerInstance.address,
-      web3.utils.toWei("1"),
+      ethers.utils.parseEther("1"),
       {
         from: wallets[0].getAddressString(),
       }

--- a/test/fixtures/Fill-Deposit-Subtree.spec.ts
+++ b/test/fixtures/Fill-Deposit-Subtree.spec.ts
@@ -4,6 +4,7 @@ const TestToken = artifacts.require("TestToken");
 const chaiAsPromised = require("chai-as-promised");
 const DepositManager = artifacts.require("DepositManager");
 import * as utils from "../../scripts/helpers/utils";
+import { ethers } from "ethers";
 
 chai.use(chaiAsPromised);
 
@@ -41,7 +42,7 @@ contract("DepositManager", async function (accounts) {
     let depositManagerInstance = await DepositManager.deployed();
     let approveToken = await testToken.approve(
       depositManagerInstance.address,
-      web3.utils.toWei("1"),
+      ethers.utils.parseEther("1"),
       {
         from: wallets[0].getAddressString(),
       }

--- a/test/fixtures/Single-Deposit.spec.ts
+++ b/test/fixtures/Single-Deposit.spec.ts
@@ -5,6 +5,7 @@ const chaiAsPromised = require("chai-as-promised");
 const DepositManager = artifacts.require("DepositManager");
 const RollupCore = artifacts.require("Rollup");
 import * as utils from "../../scripts/helpers/utils";
+import { ethers } from "ethers";
 
 chai.use(chaiAsPromised);
 
@@ -42,7 +43,7 @@ contract("DepositManager", async function (accounts) {
     let depositManagerInstance = await DepositManager.deployed();
     let approveToken = await testToken.approve(
       depositManagerInstance.address,
-      web3.utils.toWei("1"),
+      ethers.utils.parseEther("1"),
       {
         from: wallets[0].getAddressString(),
       }


### PR DESCRIPTION
This PR fix #46, which states two tasks:

- Replace web3 API with ethers'
- ~~Fix the npm install issue.~~

After investigation, I realize they are actually unrelated, but let's fix them together anyway.

Before this PR, running npm install gets this error message:

```
$ npm i
npm ERR! code EINVALIDTAGNAME
npm ERR! Invalid tag name "bignumber.js@2.0.7": Tags may not have any characters that encodeURIComponent encodes.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/liangcc/.npm/_logs/2020-06-22T15_52_55_849Z-debug.log
```

![](https://media.giphy.com/media/ZFimny5lWSU3wGRf6c/giphy.gif)