### PR TITLE
Cleanup tests a little bit

### DIFF
--- a/scripts/helpers/interfaces.ts
+++ b/scripts/helpers/interfaces.ts
@@ -1,0 +1,17 @@
+
+export interface Account {
+    ID: number,
+    tokenType: number,
+    balance: number,
+    nonce: number
+}
+
+export interface Transaction {
+    fromIndex: number,
+    toIndex: number,
+    tokenType: number,
+    amount: number,
+    txType: number,
+    nonce: number,
+    signature?: string
+}

--- a/scripts/helpers/utils.ts
+++ b/scripts/helpers/utils.ts
@@ -48,21 +48,36 @@ export async function BytesFromAccountData(
   return rollupUtils.BytesFromAccount(account);
 }
 
-export async function CreateAccountLeaf(
+export interface Account {
   ID: number,
+  tokenType: number,
   balance: number,
-  nonce: number,
-  token: number
+  nonce: number
+}
+
+export async function CreateAccountLeaf(
+  account: Account
 ) {
-  var rollupUtils = await RollupUtils.deployed();
-  // var account = {
-  //   ID: ID,
-  //   tokenType: token,
-  //   balance: balance,
-  //   nonce: nonce,
-  // };
-  var result = await rollupUtils.getAccountHash(ID, balance, nonce, token);
+  const rollupUtils = await RollupUtils.deployed();
+  const result = await rollupUtils.getAccountHash(
+    account.ID,
+    account.balance,
+    account.nonce,
+    account.tokenType
+  );
   return result;
+}
+
+export async function createLeaf(
+  accountAlias: any
+) {
+  const account: Account = {
+    ID: accountAlias.AccID,
+    balance: accountAlias.Amount,
+    tokenType: accountAlias.TokenType,
+    nonce: accountAlias.nonce,
+  };
+  return await CreateAccountLeaf(account);
 }
 
 export async function BytesFromTx(
@@ -276,7 +291,7 @@ export async function compressAndSubmitBatch(tx: Transaction, newRoot: string) {
     tx.signature
   );
 
-  const compressedTxs= [compressedTx];
+  const compressedTxs = [compressedTx];
 
   // submit batch for that transactions
   await rollupCoreInstance.submitBatch(

--- a/scripts/helpers/utils.ts
+++ b/scripts/helpers/utils.ts
@@ -1,10 +1,11 @@
 import { ethers } from "ethers";
+import * as ethUtils from "ethereumjs-util";
 const MerkleTreeUtils = artifacts.require("MerkleTreeUtils");
 const ParamManager = artifacts.require("ParamManager");
 const nameRegistry = artifacts.require("NameRegistry");
 const TokenRegistry = artifacts.require("TokenRegistry");
 const RollupUtils = artifacts.require("RollupUtils");
-import * as ethUtils from "ethereumjs-util";
+const FraudProof = artifacts.require("FraudProof");
 
 
 // returns parent node hash given child node hashes
@@ -248,4 +249,17 @@ export async function signTx(tx: Transaction, wallet: any) {
   const h = ethUtils.toBuffer(dataToSign);
   const signature = ethUtils.ecsign(h, wallet.getPrivateKey());
   return ethUtils.toRpcSig(signature.v, signature.r, signature.s);
+}
+
+export async function falseProcessTx(
+  _tx: any,
+  accountProofs: any
+) {
+  const fraudProofInstance = await FraudProof.deployed();
+  const _to_merkle_proof = accountProofs.to;
+  const new_to_txApply = await fraudProofInstance.ApplyTx(
+    _to_merkle_proof,
+    _tx
+  );
+  return new_to_txApply.newRoot;
 }

--- a/scripts/helpers/utils.ts
+++ b/scripts/helpers/utils.ts
@@ -6,6 +6,7 @@ const nameRegistry = artifacts.require("NameRegistry");
 const TokenRegistry = artifacts.require("TokenRegistry");
 const RollupUtils = artifacts.require("RollupUtils");
 const FraudProof = artifacts.require("FraudProof");
+const RollupCore = artifacts.require("Rollup");
 
 
 // returns parent node hash given child node hashes
@@ -262,4 +263,25 @@ export async function falseProcessTx(
     _tx
   );
   return new_to_txApply.newRoot;
+}
+
+export async function compressAndSubmitBatch(tx: Transaction, newRoot: string) {
+  const rollupCoreInstance = await RollupCore.deployed();
+  const compressedTx = await compressTx(
+    tx.fromIndex,
+    tx.toIndex,
+    tx.nonce,
+    tx.amount,
+    tx.tokenType,
+    tx.signature
+  );
+
+  const compressedTxs= [compressedTx];
+
+  // submit batch for that transactions
+  await rollupCoreInstance.submitBatch(
+    compressedTxs,
+    newRoot,
+    { value: ethers.utils.parseEther("32").toString() }
+  );
 }

--- a/scripts/helpers/utils.ts
+++ b/scripts/helpers/utils.ts
@@ -1,5 +1,6 @@
 import { ethers } from "ethers";
 import * as ethUtils from "ethereumjs-util";
+import { Account, Transaction } from "./interfaces";
 const MerkleTreeUtils = artifacts.require("MerkleTreeUtils");
 const ParamManager = artifacts.require("ParamManager");
 const nameRegistry = artifacts.require("NameRegistry");
@@ -46,13 +47,6 @@ export async function BytesFromAccountData(
     nonce: nonce,
   };
   return rollupUtils.BytesFromAccount(account);
-}
-
-export interface Account {
-  ID: number,
-  tokenType: number,
-  balance: number,
-  nonce: number
 }
 
 export async function CreateAccountLeaf(
@@ -239,16 +233,6 @@ export async function compressTx(
   );
   var result = await rollupUtils.CompressTxWithMessage(message, tx.signature);
   return result;
-}
-
-export interface Transaction {
-  fromIndex: number,
-  toIndex: number,
-  tokenType: number,
-  amount: number,
-  txType: number,
-  nonce: number,
-  signature?: string
 }
 
 export async function signTx(tx: Transaction, wallet: any) {

--- a/test/Deposit.spec.ts
+++ b/test/Deposit.spec.ts
@@ -1,6 +1,6 @@
 import * as chai from "chai";
 import * as walletHelper from "../scripts/helpers/wallet";
-import * as ethUtils from "ethereumjs-util";
+import { Account } from "../scripts/helpers/interfaces";
 const TestToken = artifacts.require("TestToken");
 const chaiAsPromised = require("chai-as-promised");
 const DepositManager = artifacts.require("DepositManager");
@@ -94,7 +94,7 @@ contract("DepositManager", async function (accounts) {
       Alice.TokenType,
       Alice.Pubkey
     );
-    const AliceAccount: utils.Account = {
+    const AliceAccount: Account = {
       ID: Alice.AccID,
       tokenType: Alice.TokenType,
       balance: Alice.Amount,
@@ -124,7 +124,7 @@ contract("DepositManager", async function (accounts) {
       Bob.Pubkey
     );
 
-    const BobAccount: utils.Account = {
+    const BobAccount: Account = {
       ID:Bob.AccID,
       tokenType:Bob.TokenType,
       balance: Bob.Amount,

--- a/test/Deposit.spec.ts
+++ b/test/Deposit.spec.ts
@@ -94,12 +94,13 @@ contract("DepositManager", async function (accounts) {
       Alice.TokenType,
       Alice.Pubkey
     );
-    var AliceAccountLeaf = await utils.CreateAccountLeaf(
-      Alice.AccID,
-      Alice.Amount,
-      0,
-      Alice.TokenType
-    );
+    const AliceAccount: utils.Account = {
+      ID: Alice.AccID,
+      tokenType: Alice.TokenType,
+      balance: Alice.Amount,
+      nonce: 0
+    }
+    var AliceAccountLeaf = await utils.CreateAccountLeaf(AliceAccount);
 
     var BalanceOfAliceAfterDeposit = await testTokenInstance.balanceOf(
       Alice.Address
@@ -123,12 +124,13 @@ contract("DepositManager", async function (accounts) {
       Bob.Pubkey
     );
 
-    var BobAccountLeaf = await utils.CreateAccountLeaf(
-      Bob.AccID,
-      Bob.Amount,
-      0,
-      Bob.TokenType
-    );
+    const BobAccount: utils.Account = {
+      ID:Bob.AccID,
+      tokenType:Bob.TokenType,
+      balance: Bob.Amount,
+      nonce: 0
+    }
+    var BobAccountLeaf = await utils.CreateAccountLeaf(BobAccount);
 
     var pendingDeposits0 = await depositManagerInstance.dequeue.call();
 

--- a/test/Rollup.spec.ts
+++ b/test/Rollup.spec.ts
@@ -173,8 +173,8 @@ contract("Rollup", async function (accounts) {
   });
 
   it("submit new batch 1st", async function () {
-    var AliceAccountLeaf = await createLeaf(Alice);
-    var BobAccountLeaf = await createLeaf(Bob);
+    var AliceAccountLeaf = await utils.createLeaf(Alice);
+    var BobAccountLeaf = await utils.createLeaf(Bob);
 
     // make a transfer between alice and bob's account
     var tranferAmount = 1;
@@ -235,7 +235,7 @@ contract("Rollup", async function (accounts) {
     Alice.Amount -= Number(tx.amount);
     Alice.nonce++;
 
-    var UpdatedAliceAccountLeaf = await createLeaf(Alice);
+    var UpdatedAliceAccountLeaf = await utils.createLeaf(Alice);
     // bob balance tree merkle proof
     var BobAccountSiblings: Array<string> = [
       UpdatedAliceAccountLeaf,
@@ -305,8 +305,8 @@ contract("Rollup", async function (accounts) {
   })
 
   it("submit new batch 2nd(False Batch)", async function () {
-    var AliceAccountLeaf = await createLeaf(Alice);
-    var BobAccountLeaf = await createLeaf(Bob);
+    var AliceAccountLeaf = await utils.createLeaf(Alice);
+    var BobAccountLeaf = await utils.createLeaf(Bob);
 
     // make a transfer between alice and bob's account
     var tranferAmount = 1;
@@ -365,7 +365,7 @@ contract("Rollup", async function (accounts) {
     Alice.Amount -= Number(tx.amount);
     Alice.nonce++;
 
-    var UpdatedAliceAccountLeaf = await createLeaf(Alice);
+    var UpdatedAliceAccountLeaf = await utils.createLeaf(Alice);
 
     // bob balance tree merkle proof
     var BobAccountSiblings: Array<string> = [
@@ -444,8 +444,8 @@ contract("Rollup", async function (accounts) {
 
 
   it("submit new batch 3rd", async function () {
-    var AliceAccountLeaf = await createLeaf(Alice);
-    var BobAccountLeaf = await createLeaf(Bob);
+    var AliceAccountLeaf = await utils.createLeaf(Alice);
+    var BobAccountLeaf = await utils.createLeaf(Bob);
 
     // make a transfer between alice and bob's account
     var tranferAmount = 1;
@@ -503,7 +503,7 @@ contract("Rollup", async function (accounts) {
     Alice.Amount -= Number(tx.amount);
     Alice.nonce++;
 
-    var UpdatedAliceAccountLeaf = await createLeaf(Alice);
+    var UpdatedAliceAccountLeaf = await utils.createLeaf(Alice);
 
     // bob balance tree merkle proof
     var BobAccountSiblings: Array<string> = [
@@ -604,8 +604,8 @@ contract("Rollup", async function (accounts) {
   })
 
   it("submit new batch 5nd", async function () {
-    var AliceAccountLeaf = await createLeaf(Alice);
-    var BobAccountLeaf = await createLeaf(Bob);
+    var AliceAccountLeaf = await utils.createLeaf(Alice);
+    var BobAccountLeaf = await utils.createLeaf(Bob);
 
     // make a transfer between alice and bob's account
     var tranferAmount = 1;
@@ -664,7 +664,7 @@ contract("Rollup", async function (accounts) {
     Alice.Amount -= Number(tx.amount);
     Alice.nonce++;
 
-    var UpdatedAliceAccountLeaf = await createLeaf(Alice);
+    var UpdatedAliceAccountLeaf = await utils.createLeaf(Alice);
 
     // bob balance tree merkle proof
     var BobAccountSiblings: Array<string> = [
@@ -748,8 +748,8 @@ contract("Rollup", async function (accounts) {
 
 
   it("submit new batch 6nd(False Batch)", async function () {
-    var AliceAccountLeaf = await createLeaf(Alice);
-    var BobAccountLeaf = await createLeaf(Bob);
+    var AliceAccountLeaf = await utils.createLeaf(Alice);
+    var BobAccountLeaf = await utils.createLeaf(Bob);
 
     // make a transfer between alice and bob's account
     var tranferAmount = 1;
@@ -814,7 +814,7 @@ contract("Rollup", async function (accounts) {
     Alice.Amount -= Number(tx.amount);
     Alice.nonce++;
 
-    var UpdatedAliceAccountLeaf = await createLeaf(Alice);
+    var UpdatedAliceAccountLeaf = await utils.createLeaf(Alice);
 
     // bob balance tree merkle proof
     var BobAccountSiblings: Array<string> = [
@@ -899,8 +899,8 @@ contract("Rollup", async function (accounts) {
   });
 
   it("submit new batch 7th(false batch)", async function () {
-    var AliceAccountLeaf = await createLeaf(Alice);
-    var BobAccountLeaf = await createLeaf(Bob);
+    var AliceAccountLeaf = await utils.createLeaf(Alice);
+    var BobAccountLeaf = await utils.createLeaf(Bob);
 
     // make a transfer between alice and bob's account
     var tranferAmount = 1;
@@ -958,7 +958,7 @@ contract("Rollup", async function (accounts) {
     Alice.Amount -= Number(tx.amount);
     Alice.nonce++;
 
-    var UpdatedAliceAccountLeaf = await createLeaf(Alice);
+    var UpdatedAliceAccountLeaf = await utils.createLeaf(Alice);
 
     // bob balance tree merkle proof
     var BobAccountSiblings: Array<string> = [
@@ -1036,12 +1036,3 @@ contract("Rollup", async function (accounts) {
   })
 
 });
-
-async function createLeaf(account: any) {
-  return await utils.CreateAccountLeaf(
-    account.AccID,
-    account.Amount,
-    account.nonce,
-    account.TokenType
-  );
-}

--- a/test/Rollup.spec.ts
+++ b/test/Rollup.spec.ts
@@ -8,7 +8,6 @@ const IMT = artifacts.require("IncrementalTree");
 const RollupUtils = artifacts.require("RollupUtils");
 const EcVerify = artifacts.require("ECVerify");
 const FraudProof = artifacts.require("FraudProof");
-import * as ethUtils from "ethereumjs-util";
 
 contract("Rollup", async function (accounts) {
   var wallets: any;
@@ -195,18 +194,16 @@ contract("Rollup", async function (accounts) {
     );
     assert.equal(isValid, true, "pda proof wrong");
 
-    var tx = {
+    var tx: utils.Transaction = {
       fromIndex: Alice.AccID,
       toIndex: Bob.AccID,
       tokenType: Alice.TokenType,
       amount: tranferAmount,
       txType: 1,
-      nonce: 1,
-      signature:
-        "0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563",
+      nonce: 1
     };
 
-    tx.signature = await signTx(tx, wallets);
+    tx.signature = await utils.signTx(tx, wallets[0]);
 
     // alice balance tree merkle proof
     var AliceAccountSiblings: Array<string> = [
@@ -329,18 +326,16 @@ contract("Rollup", async function (accounts) {
     );
     assert.equal(isValid, true, "pda proof wrong");
 
-    var tx = {
+    var tx: utils.Transaction = {
       fromIndex: Alice.AccID,
       toIndex: Bob.AccID,
       // tokenType: Alice.TokenType,
       tokenType: 2, // false token type (Token not valid)
       amount: tranferAmount,
       txType: 1,
-      nonce: 2,
-      signature:
-        "0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563",
+      nonce: 2
     };
-    tx.signature = await signTx(tx, wallets);
+    tx.signature = await utils.signTx(tx, wallets[0]);
 
     // alice balance tree merkle proof
     var AliceAccountSiblings: Array<string> = [
@@ -477,17 +472,15 @@ contract("Rollup", async function (accounts) {
     );
     assert.equal(isValid, true, "pda proof wrong");
 
-    var tx = {
+    var tx: utils.Transaction = {
       fromIndex: Alice.AccID,
       toIndex: Bob.AccID,
       tokenType: Alice.TokenType,
       amount: 0, // Error
       txType: 1,
-      nonce: 2,
-      signature:
-        "0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563",
+      nonce: 2
     };
-    tx.signature = await signTx(tx, wallets);
+    tx.signature = await utils.signTx(tx, wallets[0]);
 
     // alice balance tree merkle proof
     var AliceAccountSiblings: Array<string> = [
@@ -646,26 +639,16 @@ contract("Rollup", async function (accounts) {
     );
     assert.equal(isValid, true, "pda proof wrong");
 
-    var tx = {
+    var tx: utils.Transaction = {
       fromIndex: Alice.AccID,
       toIndex: Bob.AccID,
       tokenType: 2, // error
       amount: tranferAmount,
       txType: 1,
-      nonce: 2,
-      signature:
-        "0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563",
+      nonce: 2
     };
-    var dataToSign = await RollupUtilsInstance.getTxSignBytes(
-      tx.fromIndex,
-      tx.toIndex,
-      tx.tokenType,
-      tx.txType,
-      tx.nonce,
-      tx.amount
-    );
 
-    tx.signature = await signTx(tx, wallets);
+    tx.signature = await utils.signTx(tx, wallets[0]);
 
     // alice balance tree merkle proof
     var AliceAccountSiblings: Array<string> = [
@@ -815,30 +798,15 @@ contract("Rollup", async function (accounts) {
       siblings: BobPDAsiblings,
     };
 
-    var tx = {
+    var tx: utils.Transaction = {
       fromIndex: Alice.AccID,
       toIndex: Bob.AccID,
-      // tokenType: Alice.TokenType,
       tokenType: 3, // false type
       amount: tranferAmount,
       txType: 1,
-      nonce: 2,
-      signature:
-        "0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563",
+      nonce: 2
     };
-    var dataToSign = await RollupUtilsInstance.getTxSignBytes(
-      tx.fromIndex,
-      tx.toIndex,
-      tx.tokenType,
-      tx.txType,
-      tx.nonce,
-      tx.amount
-    );
-
-    const h = ethUtils.toBuffer(dataToSign);
-    var signature = ethUtils.ecsign(h, wallets[0].getPrivateKey());
-    tx.signature = ethUtils.toRpcSig(signature.v, signature.r, signature.s);
-
+    tx.signature = await utils.signTx(tx, wallets[0]);
     // alice balance tree merkle proof
     var AliceAccountSiblings: Array<string> = [
       BobAccountLeaf,
@@ -980,17 +948,15 @@ contract("Rollup", async function (accounts) {
     );
     assert.equal(isValid, true, "pda proof wrong");
 
-    var tx = {
+    var tx: utils.Transaction = {
       fromIndex: Alice.AccID,
       toIndex: Bob.AccID,
       tokenType: Alice.TokenType,
-      amount: 0, // Error
+      amount: 0, // An invalid amount
       txType: 1,
-      nonce: 2,
-      signature:
-        "0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563",
+      nonce: 2
     };
-    tx.signature = await signTx(tx, wallets);
+    tx.signature = await utils.signTx(tx, wallets[0]);
 
     // alice balance tree merkle proof
     var AliceAccountSiblings: Array<string> = [
@@ -1141,21 +1107,6 @@ async function createLeaf(account: any) {
   );
 }
 
-async function signTx(tx: any, wallets: any) {
-  let RollupUtilsInstance = await RollupUtils.deployed()
-  var dataToSign = await RollupUtilsInstance.getTxSignBytes(
-    tx.fromIndex,
-    tx.toIndex,
-    tx.tokenType,
-    tx.txType,
-    tx.nonce,
-    tx.amount
-  );
-
-  const h = ethUtils.toBuffer(dataToSign);
-  var signature = ethUtils.ecsign(h, wallets[0].getPrivateKey());
-  return ethUtils.toRpcSig(signature.v, signature.r, signature.s);
-}
 
 async function compressAndSubmitBatch(tx: any, newRoot: any) {
   let rollupCoreInstance = await RollupCore.deployed()

--- a/test/Rollup.spec.ts
+++ b/test/Rollup.spec.ts
@@ -1,6 +1,7 @@
 import * as utils from "../scripts/helpers/utils";
 import { ethers } from "ethers";
 import * as walletHelper from "../scripts/helpers/wallet";
+import { Transaction } from "../scripts/helpers/interfaces";
 const RollupCore = artifacts.require("Rollup");
 const TestToken = artifacts.require("TestToken");
 const DepositManager = artifacts.require("DepositManager");
@@ -190,7 +191,7 @@ contract("Rollup", async function (accounts) {
     );
     assert.equal(isValid, true, "pda proof wrong");
 
-    var tx: utils.Transaction = {
+    var tx: Transaction = {
       fromIndex: Alice.AccID,
       toIndex: Bob.AccID,
       tokenType: Alice.TokenType,
@@ -322,7 +323,7 @@ contract("Rollup", async function (accounts) {
     );
     assert.equal(isValid, true, "pda proof wrong");
 
-    var tx: utils.Transaction = {
+    var tx: Transaction = {
       fromIndex: Alice.AccID,
       toIndex: Bob.AccID,
       // tokenType: Alice.TokenType,
@@ -461,7 +462,7 @@ contract("Rollup", async function (accounts) {
     );
     assert.equal(isValid, true, "pda proof wrong");
 
-    var tx: utils.Transaction = {
+    var tx: Transaction = {
       fromIndex: Alice.AccID,
       toIndex: Bob.AccID,
       tokenType: Alice.TokenType,
@@ -621,7 +622,7 @@ contract("Rollup", async function (accounts) {
     );
     assert.equal(isValid, true, "pda proof wrong");
 
-    var tx: utils.Transaction = {
+    var tx: Transaction = {
       fromIndex: Alice.AccID,
       toIndex: Bob.AccID,
       tokenType: 2, // error
@@ -773,7 +774,7 @@ contract("Rollup", async function (accounts) {
       siblings: BobPDAsiblings,
     };
 
-    var tx: utils.Transaction = {
+    var tx: Transaction = {
       fromIndex: Alice.AccID,
       toIndex: Bob.AccID,
       tokenType: 3, // false type
@@ -916,7 +917,7 @@ contract("Rollup", async function (accounts) {
     );
     assert.equal(isValid, true, "pda proof wrong");
 
-    var tx: utils.Transaction = {
+    var tx: Transaction = {
       fromIndex: Alice.AccID,
       toIndex: Bob.AccID,
       tokenType: Alice.TokenType,

--- a/test/Rollup.spec.ts
+++ b/test/Rollup.spec.ts
@@ -276,7 +276,7 @@ contract("Rollup", async function (accounts) {
     );
 
     console.log("result from processTx: " + JSON.stringify(result));
-    await compressAndSubmitBatch(tx, result[0])
+    await utils.compressAndSubmitBatch(tx, result[0])
 
     falseBatchZero = {
       batchId: 0,
@@ -410,7 +410,7 @@ contract("Rollup", async function (accounts) {
       accountProofs
     );
     assert.equal(result[3], ERR_TOKEN_ADDR_INVAILD, "False error ID. It should be `1`")
-    await compressAndSubmitBatch(tx, falseResult)
+    await utils.compressAndSubmitBatch(tx, falseResult)
 
     falseBatchOne = {
       batchId: 0,
@@ -555,7 +555,7 @@ contract("Rollup", async function (accounts) {
     );
     assert.equal(result[3], ERR_TOKEN_AMT_INVAILD, "false Error Id. It should be `2`.");
 
-    await compressAndSubmitBatch(tx, falseResult)
+    await utils.compressAndSubmitBatch(tx, falseResult)
 
     falseBatchTwo = {
       batchId: 0,
@@ -715,7 +715,7 @@ contract("Rollup", async function (accounts) {
       accountProofs
     );
     assert.equal(result[3], ERR_FROM_TOKEN_TYPE, "False ErrorId. It should be `4`")
-    await compressAndSubmitBatch(tx, falseResult)
+    await utils.compressAndSubmitBatch(tx, falseResult)
 
     falseBatchFive = {
       batchId: 0,
@@ -1009,7 +1009,7 @@ contract("Rollup", async function (accounts) {
       accountProofs
     );
     assert.equal(result[3], ERR_TOKEN_AMT_INVAILD, "false ErrorId. it should be `2`");
-    await compressAndSubmitBatch(tx, falseResult)
+    await utils.compressAndSubmitBatch(tx, falseResult)
 
     falseBatchComb.txs.push(tx);
     falseBatchComb.batchProofs.accountProofs.push(accountProofs);
@@ -1043,29 +1043,5 @@ async function createLeaf(account: any) {
     account.Amount,
     account.nonce,
     account.TokenType
-  );
-}
-
-
-async function compressAndSubmitBatch(tx: any, newRoot: any) {
-  let rollupCoreInstance = await RollupCore.deployed()
-  var compressedTx = await utils.compressTx(
-    tx.fromIndex,
-    tx.toIndex,
-    tx.nonce,
-    tx.amount,
-    tx.tokenType,
-    tx.signature
-  );
-
-  let compressedTxs: string[] = [];
-  compressedTxs.push(compressedTx);
-  console.log("compressedTx: " + JSON.stringify(compressedTxs));
-
-  // submit batch for that transactions
-  await rollupCoreInstance.submitBatch(
-    compressedTxs,
-    newRoot,
-    { value: ethers.utils.parseEther("32").toString() }
   );
 }

--- a/test/Rollup.spec.ts
+++ b/test/Rollup.spec.ts
@@ -7,14 +7,12 @@ const DepositManager = artifacts.require("DepositManager");
 const IMT = artifacts.require("IncrementalTree");
 const RollupUtils = artifacts.require("RollupUtils");
 const EcVerify = artifacts.require("ECVerify");
-const FraudProof = artifacts.require("FraudProof");
 
 contract("Rollup", async function (accounts) {
   var wallets: any;
 
   let depositManagerInstance: any;
   let testTokenInstance: any;
-  let fraudProofInstance: any;
   let rollupCoreInstance: any;
   let MTutilsInstance: any;
   let testToken: any;
@@ -53,8 +51,6 @@ contract("Rollup", async function (accounts) {
 
   before(async function () {
     wallets = walletHelper.generateFirstWallets(walletHelper.mnemonics, 10);
-
-    fraudProofInstance = await FraudProof.deployed();
     depositManagerInstance = await DepositManager.deployed();
     testTokenInstance = await TestToken.deployed();
     rollupCoreInstance = await RollupCore.deployed();
@@ -409,17 +405,10 @@ contract("Rollup", async function (accounts) {
       accountProofs
     );
 
-    var falseResult = await falseProcessTx(
-      fraudProofInstance,
-      currentRoot,
-      accountRoot,
+    var falseResult = await utils.falseProcessTx(
       tx,
-      alicePDAProof,
       accountProofs
     );
-    console.log("result from falseProcessTx: " + falseResult);
-    console.log("result from processTx: " + JSON.stringify(result));
-
     assert.equal(result[3], ERR_TOKEN_ADDR_INVAILD, "False error ID. It should be `1`")
     await compressAndSubmitBatch(tx, falseResult)
 
@@ -560,17 +549,10 @@ contract("Rollup", async function (accounts) {
       accountProofs
     );
 
-    var falseResult = await falseProcessTx(
-      fraudProofInstance,
-      currentRoot,
-      accountRoot,
+    var falseResult = await utils.falseProcessTx(
       tx,
-      alicePDAProof,
       accountProofs
     );
-    console.log("result from falseProcessTx: " + falseResult);
-    console.log("result from processTx: " + JSON.stringify(result));
-    
     assert.equal(result[3], ERR_TOKEN_AMT_INVAILD, "false Error Id. It should be `2`.");
 
     await compressAndSubmitBatch(tx, falseResult)
@@ -728,17 +710,10 @@ contract("Rollup", async function (accounts) {
       accountProofs
     );
 
-    var falseResult = await falseProcessTx(
-      fraudProofInstance,
-      currentRoot,
-      accountRoot,
+    var falseResult = await utils.falseProcessTx(
       tx,
-      alicePDAProof,
       accountProofs
     );
-    console.log("result from falseProcessTx: " + falseResult);
-    console.log("result from processTx: " + JSON.stringify(result));
-    
     assert.equal(result[3], ERR_FROM_TOKEN_TYPE, "False ErrorId. It should be `4`")
     await compressAndSubmitBatch(tx, falseResult)
 
@@ -885,17 +860,10 @@ contract("Rollup", async function (accounts) {
       accountProofs
     );
 
-    var falseResult = await falseProcessTx(
-      fraudProofInstance,
-      currentRoot,
-      accountRoot,
+    var falseResult = await utils.falseProcessTx(
       tx,
-      alicePDAProof,
       accountProofs
     );
-    console.log("result from falseProcessTx: " + falseResult);
-    console.log("result from processTx: " + JSON.stringify(result));
-
     assert.equal(result[3], 1, "Wrong ErrorId")
     var compressedTx = await utils.compressTx(
       tx.fromIndex,
@@ -1036,17 +1004,10 @@ contract("Rollup", async function (accounts) {
       accountProofs
     );
 
-    var falseResult = await falseProcessTx(
-      fraudProofInstance,
-      currentRoot,
-      accountRoot,
+    var falseResult = await utils.falseProcessTx(
       tx,
-      alicePDAProof,
       accountProofs
     );
-    console.log("result from falseProcessTx: " + falseResult);
-    console.log("result from processTx: " + JSON.stringify(result));
-    
     assert.equal(result[3], ERR_TOKEN_AMT_INVAILD, "false ErrorId. it should be `2`");
     await compressAndSubmitBatch(tx, falseResult)
 
@@ -1075,28 +1036,6 @@ contract("Rollup", async function (accounts) {
   })
 
 });
-
-async function falseProcessTx(
-  FraudProofInstance: any,
-  currentRoot: any,
-  accountRoot: any,
-  _tx: any,
-  alicePDAProof: any,
-  accountProofs: any
-) {
-  var _from_merkle_proof = accountProofs.from;
-  var _to_merkle_proof = accountProofs.to;
-  let new_from_txApply = await FraudProofInstance.ApplyTx(
-    _from_merkle_proof,
-    _tx
-  );
-
-  let new_to_txApply = await FraudProofInstance.ApplyTx(
-    _to_merkle_proof,
-    _tx
-  );
-  return new_to_txApply.newRoot;
-}
 
 async function createLeaf(account: any) {
   return await utils.CreateAccountLeaf(


### PR DESCRIPTION
I'm trying to make writing tests happier. A low hanging fruit is to create more TypeScript interfaces.

Since the Typechain struct doesn't work, we currently manually deconstruct many data structures everywhere. That increased line of code and bad for readability. We should us TypeScript interfaces more in the tests itself and move deconstruction to utils.

In this PR I created the interface of Account and Transaction.