### PR TITLE
[Presentation] Use enum ErrorCode

### DIFF
--- a/contracts/interfaces/IFraudProof.sol
+++ b/contracts/interfaces/IFraudProof.sol
@@ -11,15 +11,15 @@ interface IFraudProof {
         Types.PDAMerkleProof calldata _from_pda_proof,
         Types.AccountProofs calldata accountProofs
     )
-    external
-    view
-    returns (
-      bytes32,
+        external
+        view
+        returns (
+            bytes32,
             bytes memory,
             bytes memory,
-            uint256,
+            Types.ErrorCode,
             bool
-    );
+        );
 
     function processBatch(
         bytes32 initialStateRoot,
@@ -27,14 +27,17 @@ interface IFraudProof {
         Types.Transaction[] calldata _txs,
         Types.BatchValidationProofs calldata batchProofs,
         bytes32 expectedTxRoot
-    ) external view returns (bytes32,bytes32, bool);
-
+    )
+        external
+        view
+        returns (
+            bytes32,
+            bytes32,
+            bool
+        );
 
     function ApplyTx(
         Types.AccountMerkleProof calldata _merkle_proof,
         Types.Transaction calldata transaction
-    )
-       external 
-        view
-        returns (bytes memory, bytes32 newRoot);
+    ) external view returns (bytes memory, bytes32 newRoot);
 }

--- a/contracts/libs/Types.sol
+++ b/contracts/libs/Types.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.15;
 
-
 /**
  * @title DataTypes
  */
@@ -85,5 +84,14 @@ library Types {
     struct PDAMerkleProof {
         PDAInclusionProof _pda;
         bytes32[] siblings;
+    }
+
+    enum ErrorCode {
+        NoError,
+        InvalidTokenAddress,
+        InvalidTokenAmount,
+        NotEnoughTokenBalance,
+        BadFromTokenType,
+        BadToTokenType
     }
 }

--- a/contracts/rollup.sol
+++ b/contracts/rollup.sol
@@ -48,16 +48,6 @@ contract RollupSetup {
     // will be reset to 0 once rollback is completed
     uint256 public invalidBatchMarker;
 
-    /*********************
-     * Error Codes *
-     ********************/
-    uint256 public constant NO_ERR = 0;
-    uint256 public constant ERR_TOKEN_ADDR_INVAILD = 1; // account doesnt hold token type in the tx
-    uint256 public constant ERR_TOKEN_AMT_INVAILD = 2; // tx amount is less than zero
-    uint256 public constant ERR_TOKEN_NOT_ENOUGH_BAL = 3; // leaf doesnt has enough balance
-    uint256 public constant ERR_FROM_TOKEN_TYPE = 4; // from account doesnt hold the token type in the tx
-    uint256 public constant ERR_TO_TOKEN_TYPE = 5; // to account doesnt hold the token type in the tx
-
     modifier onlyCoordinator() {
         POB pobContract = POB(
             nameRegistry.getContractDetails(ParamManager.POB())
@@ -393,7 +383,7 @@ contract Rollup is RollupHelpers {
             bytes32,
             bytes memory,
             bytes memory,
-            uint256,
+            Types.ErrorCode,
             bool
         )
     {

--- a/scripts/helpers/interfaces.ts
+++ b/scripts/helpers/interfaces.ts
@@ -15,3 +15,12 @@ export interface Transaction {
     nonce: number,
     signature?: string
 }
+
+export enum ErrorCode {
+    NoError,
+    InvalidTokenAddress,
+    InvalidTokenAmount,
+    NotEnoughTokenBalance,
+    BadFromTokenType,
+    BadToTokenType
+}

--- a/test/Rollup.spec.ts
+++ b/test/Rollup.spec.ts
@@ -1,7 +1,7 @@
 import * as utils from "../scripts/helpers/utils";
 import { ethers } from "ethers";
 import * as walletHelper from "../scripts/helpers/wallet";
-import { Transaction } from "../scripts/helpers/interfaces";
+import { Transaction, ErrorCode } from "../scripts/helpers/interfaces";
 const RollupCore = artifacts.require("Rollup");
 const TestToken = artifacts.require("TestToken");
 const DepositManager = artifacts.require("DepositManager");
@@ -42,13 +42,6 @@ contract("Rollup", async function (accounts) {
   let BobPDAsiblings: any;
 
   let alicePDAProof: any;
-
-    let NO_ERR = 0;
-    let ERR_TOKEN_ADDR_INVAILD = 1; // account doesnt hold token type in the tx
-    let ERR_TOKEN_AMT_INVAILD = 2; // tx amount is less than zero
-    let ERR_TOKEN_NOT_ENOUGH_BAL = 3; // leaf doesnt has enough balance
-    let ERR_FROM_TOKEN_TYPE = 4; // from account doesnt hold the token type in the tx
-    let ERR_TO_TOKEN_TYPE = 5; // to account doesnt hold the token type in the tx
 
   before(async function () {
     wallets = walletHelper.generateFirstWallets(walletHelper.mnemonics, 10);
@@ -410,7 +403,7 @@ contract("Rollup", async function (accounts) {
       tx,
       accountProofs
     );
-    assert.equal(result[3], ERR_TOKEN_ADDR_INVAILD, "False error ID. It should be `1`")
+    assert.equal(result[3], ErrorCode.InvalidTokenAddress, "False error ID. It should be `1`");
     await utils.compressAndSubmitBatch(tx, falseResult)
 
     falseBatchOne = {
@@ -554,7 +547,7 @@ contract("Rollup", async function (accounts) {
       tx,
       accountProofs
     );
-    assert.equal(result[3], ERR_TOKEN_AMT_INVAILD, "false Error Id. It should be `2`.");
+    assert.equal(result[3], ErrorCode.InvalidTokenAmount, "false Error Id. It should be `2`.");
 
     await utils.compressAndSubmitBatch(tx, falseResult)
 
@@ -715,7 +708,7 @@ contract("Rollup", async function (accounts) {
       tx,
       accountProofs
     );
-    assert.equal(result[3], ERR_FROM_TOKEN_TYPE, "False ErrorId. It should be `4`")
+    assert.equal(result[3], ErrorCode.BadFromTokenType, "False ErrorId. It should be `4`")
     await utils.compressAndSubmitBatch(tx, falseResult)
 
     falseBatchFive = {
@@ -1009,7 +1002,7 @@ contract("Rollup", async function (accounts) {
       tx,
       accountProofs
     );
-    assert.equal(result[3], ERR_TOKEN_AMT_INVAILD, "false ErrorId. it should be `2`");
+    assert.equal(result[3], ErrorCode.InvalidTokenAmount, "false ErrorId. it should be `2`");
     await utils.compressAndSubmitBatch(tx, falseResult)
 
     falseBatchComb.txs.push(tx);


### PR DESCRIPTION
We attempt to organize ErrorCodes in contracts/libs/Types.sol .

Benefits:

- Easier to find where all the error codes are.
- Easier to extend a new error code without worrying about duplicating their error code numbers. Need more error code types for Reddit txs.
- We now type checking with Types.ErrorCode instead of the generic uint256.
- Save a little bit of deployment gas. Enums use the smallest possible uint, so the size should be smaller than uint256.

### Gas cost

Before:

FraudProof: 3280500
Rollup: 5146599 (Error codes are defined but not used in Rollup anyway)
Types: 71714

After:

FraudProof: 3244821
Rollup: 5078364
Types: 71714
